### PR TITLE
New: [AEA-4347] - Wrap datastore methods in timer

### DIFF
--- a/SAMtemplates/tables/main.yaml
+++ b/SAMtemplates/tables/main.yaml
@@ -33,7 +33,6 @@ Resources:
           Projection:
             ProjectionType: INCLUDE
             NonKeyAttributes:
-              - prescriptionId
               - nhsNumberDate
 
   DynamoDbPocResources:

--- a/SAMtemplates/tables/main.yaml
+++ b/SAMtemplates/tables/main.yaml
@@ -15,6 +15,8 @@ Resources:
       AttributeDefinitions:
         - AttributeName: pk
           AttributeType: S
+        - AttributeName: sk
+          AttributeType: S
         - AttributeName: nhsNumber
           AttributeType: S
         - AttributeName: creationDatetime
@@ -22,6 +24,8 @@ Resources:
       KeySchema:
         - AttributeName: pk
           KeyType: HASH
+        - AttributeName: sk
+          KeyType: RANGE
       BillingMode: PAY_PER_REQUEST
       GlobalSecondaryIndexes:
         - IndexName: nhsNumberDateIndex


### PR DESCRIPTION
## Summary

Removed redundant projection attribute from nhsNumberDate index.